### PR TITLE
Fix non-constant format strings

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -34,12 +34,12 @@ func TestReadHeader(t *testing.T) {
 	defer f.Close()
 
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	reader := NewReader(f)
 	header, err := reader.Next()
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	expectedName := "hello.txt"
@@ -69,12 +69,12 @@ func TestReadBody(t *testing.T) {
 	defer f.Close()
 
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	reader := NewReader(f)
 	_, err = reader.Next()
 	if err != nil && err != io.EOF {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	var buf bytes.Buffer
 	io.Copy(&buf, reader)
@@ -91,7 +91,7 @@ func TestReadMulti(t *testing.T) {
 	defer f.Close()
 
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	reader := NewReader(f)
 	var buf bytes.Buffer
@@ -101,7 +101,7 @@ func TestReadMulti(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 		io.Copy(&buf, reader)
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -33,7 +33,7 @@ func TestGlobalHeaderWrite(t *testing.T) {
 	var buf bytes.Buffer
 	writer := NewWriter(&buf)
 	if err := writer.WriteGlobalHeader(); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	globalHeader := buf.Bytes()
@@ -59,7 +59,7 @@ func TestSimpleFile(t *testing.T) {
 	writer.WriteHeader(hdr)
 	_, err := writer.Write([]byte(body))
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	f, _ := os.Open("./fixtures/hello.a")
@@ -67,7 +67,7 @@ func TestSimpleFile(t *testing.T) {
 
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	actual := buf.Bytes()


### PR DESCRIPTION
This is now a problem with Go 1.24, as `go test` does a vet check for it. https://go.dev/doc/go1.24#vet