### PR TITLE
ar: add a NewStrictReader

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2013 Blake Smith <blakesmith0@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -26,17 +26,18 @@ import (
 )
 
 const (
-	HEADER_BYTE_SIZE = 60
-	GLOBAL_HEADER = "!<arch>\n"
+	HEADER_BYTE_SIZE     = 60
+	GLOBAL_HEADER        = "!<arch>\n"
+	GLOBAL_HEADER_LENGTH = 8
 )
 
 type Header struct {
-	Name string
+	Name    string
 	ModTime time.Time
-	Uid int
-	Gid int
-	Mode int64
-	Size int64
+	Uid     int
+	Gid     int
+	Mode    int64
+	Size    int64
 }
 
 type slicer []byte

--- a/reader.go
+++ b/reader.go
@@ -70,6 +70,9 @@ func NewReader(r io.Reader) *Reader {
 func NewStrictReader(r io.Reader) (*Reader, error) {
 	var b bytes.Buffer
 	if _, err := io.CopyN(&b, r, GLOBAL_HEADER_LENGTH); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, ErrBadMagicHeader
+		}
 		return nil, err
 	}
 	if string(b.Bytes()) != GLOBAL_HEADER {

--- a/reader.go
+++ b/reader.go
@@ -106,7 +106,9 @@ func (rd *Reader) octal(b []byte) int64 {
 	for i > 0 && b[i] == 32 {
 		i--
 	}
-
+	if i <= 2 {
+		return 0
+	}
 	n, _ := strconv.ParseInt(string(b[3:i+1]), 8, 64)
 
 	return n

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2013 Blake Smith <blakesmith0@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -37,6 +37,44 @@ func TestReadHeader(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	reader := NewReader(f)
+	header, err := reader.Next()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	expectedName := "hello.txt"
+	if header.Name != expectedName {
+		t.Errorf("Header name should be %s but is %s", expectedName, header.Name)
+	}
+	expectedModTime := time.Unix(1361157466, 0)
+	if header.ModTime != expectedModTime {
+		t.Errorf("ModTime should be %s but is %s", expectedModTime, header.ModTime)
+	}
+	expectedUid := 501
+	if header.Uid != expectedUid {
+		t.Errorf("Uid should be %d but is %d", expectedUid, header.Uid)
+	}
+	expectedGid := 20
+	if header.Gid != expectedGid {
+		t.Errorf("Gid should be %d but is %d", expectedGid, header.Gid)
+	}
+	expectedMode := int64(0644)
+	if header.Mode != expectedMode {
+		t.Errorf("Mode should be %d but is %d", expectedMode, header.Mode)
+	}
+}
+
+func TestReadStrictHeader(t *testing.T) {
+	f, err := os.Open("./fixtures/hello.a")
+	defer f.Close()
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	reader, err := NewStrictReader(f)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	header, err := reader.Next()
 	if err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
The NewReader method in reader.go doesn't check that the magic header is correct, this leads to some strange things, like ascii text files being parsed without any error.

This change is a suggestion to add a NewStrictReader which checks for the magic header.